### PR TITLE
Fix installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Detect OS and Architecture
 OS="$(uname -s)"
-ARCH="$(uname -m)"
+ARCH="$(uname -m | sed s/x86_64/amd64/)"
 
 echo "Detected OS: $OS, Architecture: $ARCH"
 


### PR DESCRIPTION
The installation script is currently failing when running on my linux machine.

The reason for this is that the command `uname -m` returns `x86_64` instead of amd64.

```shell
$ uname -m
x86_64
```

As you do not have a release with the `x86_64` suffix, the curl command will fail. So I added a command to rename the `uname -m` output to fix this issue.

Also, according to this [discussion](https://stackoverflow.com/questions/45125516/possible-values-for-uname-m), in Linux computers the `uname -m` can return `aarch64_be`, `aarch64`, `armv8b`, `armv8l` for the `arm64` architecture. However, I do not have any linux with an arm processor to test this.